### PR TITLE
Only the scheme and host MUST be in lowercase.

### DIFF
--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -115,7 +115,7 @@ class OAuth
       url = URI.parse(uri)
       # Lowercase scheme and authority
       # Remove query and fragment
-      "#{url.scheme.downcase}://#{url.host.downcase}#{url.path.downcase}"
+      "#{url.scheme.downcase}://#{url.host.downcase}#{url.path}"
     end
 
     #

--- a/tests/test_get_base_uri_string.rb
+++ b/tests/test_get_base_uri_string.rb
@@ -12,4 +12,11 @@ class TestGetBaseUriString < Minitest::Test
 
     assert_equal(base_uri, 'https://sandbox.api.mastercard.com/merchantid/v1/merchantid')
   end
+
+  def test_creates_a_normalized_url_with_uppercase_path
+    href = 'https://sandbox.api.mastercard.com/merchantid/v1/getMerchantId?MerchantId=GOOGLE%20LTD%20ADWORDS%20%28CC%40GOOGLE.COM%29&Format=XML&Type=ExactMatch&Format=JSON'
+    base_uri = OAuth.get_base_uri_string(href)
+
+    assert_equal(base_uri, 'https://sandbox.api.mastercard.com/merchantid/v1/getMerchantId')
+  end
 end


### PR DESCRIPTION
Only the scheme and host MUST be in lowercase, don't downcase the URL path.
