### PR TITLE
Create correct auth header

### DIFF
--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -98,7 +98,7 @@ class OAuth
       oauth_params.each {|entry|
         entry_key = entry[0]
         entry_val = entry[1]
-        header = "#{header}#{entry_key}='#{entry_val}',"
+        header = "#{header}#{entry_key}=\"#{entry_val}\","
       }
       # Remove trailing ,
       header.slice(0, header.length - 1)

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -98,7 +98,7 @@ class OAuth
       oauth_params.each {|entry|
         entry_key = entry[0]
         entry_val = entry[1]
-        header = "#{header}#{entry_key} = '#{entry_val}',"
+        header = "#{header}#{entry_key}='#{entry_val}',"
       }
       # Remove trailing ,
       header.slice(0, header.length - 1)

--- a/tests/test_get_authorization_string.rb
+++ b/tests/test_get_authorization_string.rb
@@ -14,7 +14,7 @@ class TestGetAuthorizationString < Minitest::Test
       OAuth.stub(:time_stamp, "1524771555") do
         oauth_params = OAuth.get_oauth_params consumer_key
         authorization_string = OAuth.get_authorization_string oauth_params
-        assert_equal authorization_string, "OAuth oauth_consumer_key='aaa!aaa',oauth_nonce='uTeLPs6K',oauth_signature_method='RSA-SHA256',oauth_timestamp='1524771555',oauth_version='1.0'"
+        assert_equal authorization_string, 'OAuth oauth_consumer_key="aaa!aaa",oauth_nonce="uTeLPs6K",oauth_signature_method="RSA-SHA256",oauth_timestamp="1524771555",oauth_version="1.0"'
       end
     end
   end

--- a/tests/test_get_authorization_string.rb
+++ b/tests/test_get_authorization_string.rb
@@ -14,7 +14,7 @@ class TestGetAuthorizationString < Minitest::Test
       OAuth.stub(:time_stamp, "1524771555") do
         oauth_params = OAuth.get_oauth_params consumer_key
         authorization_string = OAuth.get_authorization_string oauth_params
-        assert_equal authorization_string, "OAuth oauth_consumer_key = 'aaa!aaa',oauth_nonce = 'uTeLPs6K',oauth_signature_method = 'RSA-SHA256',oauth_timestamp = '1524771555',oauth_version = '1.0'"
+        assert_equal authorization_string, "OAuth oauth_consumer_key='aaa!aaa',oauth_nonce='uTeLPs6K',oauth_signature_method='RSA-SHA256',oauth_timestamp='1524771555',oauth_version='1.0'"
       end
     end
   end

--- a/tests/test_oauth.rb
+++ b/tests/test_oauth.rb
@@ -17,7 +17,7 @@ class OAuthTest < Minitest::Test
       OAuth.stub(:sign_signature_base_string, "XXX") do
         OAuth.stub(:time_stamp, "1524771555") do
           header = OAuth.get_authorization_header uri, method, nil, consumer_key, signing_key
-          assert_equal header, "OAuth oauth_consumer_key = 'aaa!aaa',oauth_nonce = 'uTeLPs6K',oauth_signature_method = 'RSA-SHA256',oauth_timestamp = '1524771555',oauth_version = '1.0',oauth_signature = 'XXX'"
+          assert_equal header, 'OAuth oauth_consumer_key="aaa!aaa",oauth_nonce="uTeLPs6K",oauth_signature_method="RSA-SHA256",oauth_timestamp="1524771555",oauth_version="1.0",oauth_signature="XXX"'
         end
       end
     end


### PR DESCRIPTION
Closing #4: 
- Use double quotes instead of single quotes for auth parameters.
- Remove trailing spaces in the authorization header.

Build passing here: https://travis-ci.org/Mastercard/oauth1-signer-ruby/builds/527726614.